### PR TITLE
Fixed link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## DiogoNunes.com
 
-This repo contains my **personal website**. You can check it at [www.diogonunes.com](www.diogonunes.com)
+This repo contains my **personal website**. You can check it at [www.diogonunes.com](http://www.diogonunes.com)
 
 *Since 12:34:56 07/08/2009.*


### PR DESCRIPTION
The links have to have the http to properly work, otherwise the markup considers it a relative link.
